### PR TITLE
Fix mobile chat overlay drift

### DIFF
--- a/components/InteractionScreen.tsx
+++ b/components/InteractionScreen.tsx
@@ -714,22 +714,39 @@ export const InteractionScreen: React.FC<InteractionScreenProps> = ({
 				window.removeEventListener("resize", calculateExclusionZones);
 			};
 		}
-	}, []);
+        }, []);
 
-	// Add this useEffect near other effects in InteractionScreen
-	useEffect(() => {
-		const handleResize = () => {
-			if (
-				window.innerWidth < 768 &&
-				screenDimmed &&
-				!showScenarioContextModal
-			) {
-				setScreenDimmed(false);
-			}
-		};
-		window.addEventListener("resize", handleResize);
-		return () => window.removeEventListener("resize", handleResize);
-	}, [screenDimmed, showScenarioContextModal]);
+        // Add this useEffect near other effects in InteractionScreen
+        useEffect(() => {
+                const handleResize = () => {
+                        if (
+                                window.innerWidth < 768 &&
+                                screenDimmed &&
+                                !showScenarioContextModal
+                        ) {
+                                setScreenDimmed(false);
+                        }
+                };
+                window.addEventListener("resize", handleResize);
+                return () => window.removeEventListener("resize", handleResize);
+        }, [screenDimmed, showScenarioContextModal]);
+
+        // Set --vh CSS variable to handle mobile viewport height changes
+        useEffect(() => {
+                const setViewportHeight = () => {
+                        if (typeof window !== "undefined") {
+                                const vh = window.innerHeight * 0.01;
+                                document.documentElement.style.setProperty(
+                                        "--vh",
+                                        `${vh}px`
+                                );
+                        }
+                };
+
+                setViewportHeight();
+                window.addEventListener("resize", setViewportHeight);
+                return () => window.removeEventListener("resize", setViewportHeight);
+        }, []);
 
 	// Ensure dim overlay is cleared whenever the scenario context modal is fully closed
 	useEffect(() => {
@@ -742,10 +759,11 @@ export const InteractionScreen: React.FC<InteractionScreenProps> = ({
 	}, [showScenarioContextModal, screenDimmed]);
 
 	return (
-		<div
-			className={`w-full max-w-7xl h-[85vh] flex flex-col md:flex-row shadow-2xl rounded-xl relative overflow-hidden ${
-				hasCompletedFirstLoad ? "bg-slate-800" : "bg-transparent"
-			}`}>
+               <div
+                       className={`w-full max-w-7xl flex flex-col md:flex-row shadow-2xl rounded-xl relative overflow-hidden ${
+                               hasCompletedFirstLoad ? "bg-slate-800" : "bg-transparent"
+                       }`}
+                       style={{ height: "calc(var(--vh, 1vh) * 85)" }}>
 			{/* Global fade overlay for smooth cross-fades (desktop & mobile) */}
 			<AnimatePresence>
 				{isGlobalFading && (
@@ -1160,15 +1178,15 @@ export const InteractionScreen: React.FC<InteractionScreenProps> = ({
 			)}
 
 			{/* Mobile: Full Screen Chat Overlay */}
-			{chatOverlayIsVisible && (
-				<div
-					className={`md:hidden fixed inset-0 z-[9998] bg-black transition-opacity duration-200 ${
-						showChatOverlay
-							? "animate-chat-overlay-in"
-							: "animate-chat-overlay-out pointer-events-none"
-					}`}
-					role="dialog"
-					aria-modal="true">
+               {chatOverlayIsVisible && (
+                               <div
+                                       className={`md:hidden fixed inset-0 z-[9998] bg-black transition-opacity duration-200 overscroll-contain ${
+                                               showChatOverlay
+                                                       ? "animate-chat-overlay-in"
+                                                       : "animate-chat-overlay-out pointer-events-none"
+                                       }`}
+                                       role="dialog"
+                                       aria-modal="true">
 					{/* Solid background to prevent image pop-in */}
 					<div className="absolute inset-0 bg-black" />
 					{chatOverlayImageVisible && (

--- a/components/RenderChatInterface.tsx
+++ b/components/RenderChatInterface.tsx
@@ -669,13 +669,8 @@ export const RenderChatInterface: React.FC<RenderChatInterfaceProps> = ({
 					ref={chatContainerRef}
 					className="flex-grow min-h-0 overflow-y-auto px-2 sm:px-4 pt-4 pb-2"
 					onClick={() => setActivePopoverId(null)}>
-					{isOverlay ? (
-						<motion.div
-							drag="y"
-							dragConstraints={{ top: -60, bottom: 60 }}
-							dragElastic={0.12}
-							transition={{ type: "spring", stiffness: 520, damping: 44 }}
-							style={{ touchAction: "pan-y" }}>
+                                        {isOverlay ? (
+                                                <div style={{ touchAction: "pan-y" }}>
 							<div className="space-y-4">
 								{processedMessagesForDisplay.map((msg, index) => (
 									<motion.div
@@ -739,15 +734,10 @@ export const RenderChatInterface: React.FC<RenderChatInterfaceProps> = ({
 								))}
 								{isLoadingAI && <ChatMessageViewAIThinking />}
 								<div ref={chatEndRef} />
-							</div>
-						</motion.div>
-					) : (
-						<motion.div
-							drag="y"
-							dragConstraints={{ top: -60, bottom: 60 }}
-							dragElastic={0.12}
-							transition={{ type: "spring", stiffness: 520, damping: 44 }}
-							style={{ touchAction: "pan-y" }}>
+                                                        </div>
+                                                </div>
+                                        ) : (
+                                                <div style={{ touchAction: "pan-y" }}>
 							<div className="space-y-4">
 								{processedMessagesForDisplay.map((msg, index) => (
 									<motion.div
@@ -811,9 +801,9 @@ export const RenderChatInterface: React.FC<RenderChatInterfaceProps> = ({
 								))}
 								{isLoadingAI && <ChatMessageViewAIThinking />}
 								<div ref={chatEndRef} />
-							</div>
-						</motion.div>
-					)}
+                                                        </div>
+                                                </div>
+                                        )}
 				</div>
 
 				{pendingFeedback && (


### PR DESCRIPTION
## Summary
- set `--vh` CSS variable for mobile viewport height
- use the CSS variable to size `InteractionScreen`
- prevent page overscroll when chat overlay is open
- remove drag behavior from the scrolling container

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run lint` *(fails: Failed to load config "next/typescript" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_686c935e55f4832c9c0f8e14a201a18a