### PR TITLE
Fix viewport height calculation

### DIFF
--- a/components/InitialLoadingScreen.tsx
+++ b/components/InitialLoadingScreen.tsx
@@ -433,10 +433,27 @@ export const InitialLoadingScreen: React.FC<InitialLoadingScreenProps> = ({
 	]);
 
 	// Effect hooks - ALWAYS called in the same order
-	// Hydration safety - ensure client-side rendering
-	useEffect(() => {
-		setIsClient(true);
-	}, []);
+        // Hydration safety - ensure client-side rendering
+        useEffect(() => {
+                setIsClient(true);
+        }, []);
+
+        // Set --vh CSS variable to handle mobile viewport height changes
+        useEffect(() => {
+                const setViewportHeight = () => {
+                        if (typeof window !== "undefined") {
+                                const vh = window.innerHeight * 0.01;
+                                document.documentElement.style.setProperty(
+                                        "--vh",
+                                        `${vh}px`
+                                );
+                        }
+                };
+
+                setViewportHeight();
+                window.addEventListener("resize", setViewportHeight);
+                return () => window.removeEventListener("resize", setViewportHeight);
+        }, []);
 
 	// Start loading sequence
 	useEffect(() => {
@@ -522,10 +539,15 @@ export const InitialLoadingScreen: React.FC<InitialLoadingScreenProps> = ({
 
 	// 🔥 CRITICAL: Early return ONLY AFTER all hooks are declared
 	// This prevents "Rendered fewer hooks than expected" errors
-	if (!isClient) {
-		// Render a blank black screen during hydration to avoid showing 'Loading...'
-		return <div className="fixed inset-0 bg-black z-50 w-screen h-screen" />;
-	}
+        if (!isClient) {
+                // Render a blank black screen during hydration to avoid showing 'Loading...'
+                return (
+                        <div
+                                className="fixed inset-0 bg-black z-50 w-screen"
+                                style={{ height: "calc(var(--vh, 1vh) * 100)" }}
+                        />
+                );
+        }
 
 	if (!isVisible && animationComplete) {
 		return null;
@@ -633,16 +655,17 @@ export const InitialLoadingScreen: React.FC<InitialLoadingScreenProps> = ({
 		<>
 			<StyleInjector />
 			<AnimatePresence>
-				{showBlack && (
-					<motion.div
-						key="black-overlay"
-						className="fixed inset-0 z-[10000] bg-black w-screen h-screen"
-						initial={{ opacity: 1 }}
-						animate={{ opacity: 1 }}
-						exit={{ opacity: 0 }}
-						transition={{ duration: 0.35, ease: "easeInOut" }}
-					/>
-				)}
+                                {showBlack && (
+                                        <motion.div
+                                                key="black-overlay"
+                                                className="fixed inset-0 z-[10000] bg-black w-screen"
+                                                style={{ height: "calc(var(--vh, 1vh) * 100)" }}
+                                                initial={{ opacity: 1 }}
+                                                animate={{ opacity: 1 }}
+                                                exit={{ opacity: 0 }}
+                                                transition={{ duration: 0.35, ease: "easeInOut" }}
+                                        />
+                                )}
 			</AnimatePresence>
 			{!showBlack && showContent && (
 				<AnimatePresence mode="wait">
@@ -658,7 +681,7 @@ export const InitialLoadingScreen: React.FC<InitialLoadingScreenProps> = ({
 									right: 0,
 									bottom: 0,
 									width: "100vw",
-									height: "100vh",
+                                                                        height: "calc(var(--vh, 1vh) * 100)",
 									position: "fixed",
 									backgroundColor: "#000",
 								}}
@@ -687,7 +710,7 @@ export const InitialLoadingScreen: React.FC<InitialLoadingScreenProps> = ({
 										display: "flex",
 										alignItems: "center",
 										justifyContent: "center",
-										minHeight: "100vh",
+                                                                               minHeight: "calc(var(--vh, 1vh) * 100)",
 										minWidth: "100vw",
 										padding: "1rem",
 									}}>

--- a/components/InteractionScreen.tsx
+++ b/components/InteractionScreen.tsx
@@ -922,7 +922,7 @@ export const InteractionScreen: React.FC<InteractionScreenProps> = ({
 						visibility: showChatOverlay ? "hidden" : "visible",
 						transformOrigin: "center center",
 						overscrollBehavior: "contain",
-						maxHeight: "100vh",
+                                                maxHeight: "calc(var(--vh, 1vh) * 100)",
 					}}>
 					<AIVisualCue
 						imageBase64={aiImageBase64}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1481,9 +1481,14 @@ const HomePage: React.FC = () => {
 									? "justify-center overflow-hidden"
 									: "justify-start py-4 overflow-y-auto"
 							} ${isModalActive ? "pointer-events-none" : ""}`}
-							style={
-								isMobileLandscape ? { padding: 0, minHeight: "100vh" } : {}
-							}>
+                                                        style={
+                                                                isMobileLandscape
+                                                                        ? {
+                                                                                padding: 0,
+                                                                                minHeight: "calc(var(--vh, 1vh) * 100)",
+                                                                        }
+                                                                        : {}
+                                                        }>
 							{renderContent()}
 						</main>
 

--- a/styles/loading-animations.css
+++ b/styles/loading-animations.css
@@ -74,25 +74,25 @@
 
 /* Ensure proper full-screen coverage */
 .loading-screen-container {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	width: 100vw;
-	height: 100vh;
-	z-index: 10000;
-	background-color: #000000;
-	overflow: hidden;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100vw;
+        height: calc(var(--vh, 1vh) * 100);
+        z-index: 10000;
+        background-color: #000000;
+        overflow: hidden;
 }
 
 /* Perfect centering utility */
 .loading-screen-center {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-height: 100vh;
-	min-width: 100vw;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(var(--vh, 1vh) * 100);
+        min-width: 100vw;
 }
 
 /* Content container */


### PR DESCRIPTION
## Summary
- set CSS `--vh` variable in `InitialLoadingScreen`
- replace static `100vh` usage with `calc(var(--vh, 1vh) * 100)`
- update `loading-animations.css` to use viewport variable

## Testing
- `npm test` *(fails: SyntaxError in geminiService)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0637a7c832c9e5e43a5d7585ecd