### PR TITLE
Fix loading screen width overflow

### DIFF
--- a/styles/loading-animations.css
+++ b/styles/loading-animations.css
@@ -74,25 +74,27 @@
 
 /* Ensure proper full-screen coverage */
 .loading-screen-container {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	width: 100vw;
-	height: 100vh;
-	z-index: 10000;
-	background-color: #000000;
-	overflow: hidden;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        max-width: 100vw;
+        height: 100vh;
+        z-index: 10000;
+        background-color: #000000;
+        overflow: hidden;
 }
 
 /* Perfect centering utility */
 .loading-screen-center {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-height: 100vh;
-	min-width: 100vw;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        width: 100%;
+        max-width: 100vw;
 }
 
 /* Content container */


### PR DESCRIPTION
## Summary
- use `width: 100%` with `max-width: 100vw` for loading screen container
- do the same for loading screen center

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0652a9c832c99a2726cfb401e33